### PR TITLE
fix: pass truncate_for_generation=False in train/val collate_fn to preserve SFT supervision

### DIFF
--- a/train_dna_qwen.py
+++ b/train_dna_qwen.py
@@ -407,8 +407,9 @@ class DNALLMFineTuner(pl.LightningModule):
                 max_length_text=self.max_length_text,
                 max_length_dna=self.max_length_dna,
                 return_answer_in_batch=self.return_answer_in_batch,
+                truncate_for_generation=False,
             )
-                
+
 
         elif self.hparams.dataset_type == "variant_effect_coding":
             dataset = load_dataset(self.hparams.variant_effect_coding_data_dir_huggingface)
@@ -439,8 +440,9 @@ class DNALLMFineTuner(pl.LightningModule):
                 max_length_text=self.max_length_text,
                 max_length_dna=self.max_length_dna,
                 return_answer_in_batch=self.return_answer_in_batch,
+                truncate_for_generation=False,
             )
-        
+
         elif self.hparams.dataset_type == "variant_effect_non_snv":
             dataset = load_dataset(self.hparams.variant_effect_non_snv_data_dir_huggingface)
             dataset = dataset.map(clean_variant_effect_non_snv_example)
@@ -472,6 +474,7 @@ class DNALLMFineTuner(pl.LightningModule):
                 max_length_text=self.max_length_text,
                 max_length_dna=self.max_length_dna,
                 return_answer_in_batch=self.return_answer_in_batch,
+                truncate_for_generation=False,
             )
 
         else:
@@ -561,6 +564,7 @@ class DNALLMFineTuner(pl.LightningModule):
                 max_length_text=self.max_length_text,
                 max_length_dna=self.max_length_dna,
                 return_answer_in_batch=self.return_answer_in_batch,
+                truncate_for_generation=False,
             )
 
         return DataLoader(


### PR DESCRIPTION
## Summary

`train_dna_qwen.py` builds the training and validation `DataLoader`s with a `partial` of `qwen_dna_collate_fn` that does not pass `truncate_for_generation`. The default of that kwarg in `bioreason/dataset/kegg.py:97` is `True`, which causes the collator to **truncate `input_ids`, `attention_mask`, and `labels` at the `<|im_start|>assistant\n` marker — discarding the entire assistant answer span**.

Because SFT loss in `_step` (`train_dna_qwen.py:168-177`) is computed as

```python
outputs = self.model(input_ids=..., attention_mask=..., labels=labels)
loss = outputs.loss
```

the answer tokens that should carry supervision are no longer present in the batch. All positions that would have held real label IDs have been dropped along with the tokens, so the remaining `labels` are almost entirely `-100` (padding) plus the marker itself. Effectively, **training and validation loss is computed over a near-empty supervision target**, silently disabling SFT.

This PR fixes the four `partial(qwen_dna_collate_fn, ...)` call sites in `train_dna_qwen.py` to explicitly pass `truncate_for_generation=False`, so the answer span is preserved end-to-end through the batch and loss is computed correctly.

## Root cause

1. `qwen_dna_collate_fn` signature (`bioreason/dataset/kegg.py:92-98`):
   ```python
   def qwen_dna_collate_fn(
       examples, processor, max_length_text, max_length_dna,
       return_answer_in_batch: bool = False,
       truncate_for_generation: bool = True,   # <-- default True
   ) -> Dict:
   ```

2. When `True`, the collator (`kegg.py:206-253`) scans each sample for the composite marker `"<|im_end|>\n<|im_start|>assistant\n"` and rebuilds `input_ids` / `attention_mask` / `labels` to include **only** tokens up to and including that marker, then left-pads. This is correct **for generation-time batches**, but wrong for loss computation because labels on the answer are thrown away.

3. `train_dna_qwen.py` never overrides this default at the four training-relevant call sites:
   - `train_dataloader()` — kegg branch (around L405)
   - `train_dataloader()` — `variant_effect_coding` branch (around L437)
   - `train_dataloader()` — `variant_effect_non_snv` branch (around L470)
   - `val_dataloader()` — shared collate for all dataset types (around L559)

4. `test_dataloader` returns `self.val_dataloader()` (L578), and `_step` short-circuits with `loss=0` when `prefix == "test"` (L155-156), so the loss path only actually runs for `train` and `val` — both of which go through the broken default.

## Why this does not break generation

The on-the-fly sample generation (`_step`, L181–304) and the batched test-time generation (`on_test_epoch_end`, L647–706) do **not** rely on the collator's truncation. They re-scan each `input_ids` row for the assistant marker per-sample and slice `gen_input_ids = input_ids[..., start_idx : assistant_pos + marker_len]` manually. With `truncate_for_generation=False`, the marker is still present in `input_ids` (just followed by the answer tokens), and the per-sample slice still yields the correct generation input. So setting this flag to `False` at the training/validation collate sites does not regress the generation / evaluation paths.

## Scope

- Only `train_dna_qwen.py` is touched. `train_dna_only.py` uses a different collator (`dna_collate_fn`) without this parameter, and `train_grpo.py` uses its own batching logic — neither is affected.
- `qwen_dna_collate_fn` itself is untouched. A follow-up could change its default from `True` to `False` and have explicit generation callers opt in, but that is a larger behavioral change left out of this PR to keep the diff surgical.

## Test plan

- [ ] Run `python train_dna_qwen.py --dataset_type kegg --num_gpus 1 --max_epochs 1` on a subset and confirm `train_loss_epoch` shows a normal SFT descent curve (previously it collapses to ~0 / NaN immediately because there is almost no supervision signal).
- [ ] Verify the periodic sample generation print block in `_step` still prints coherent user_input / ground_truth pairs.
- [ ] Run test/eval and confirm `on_test_epoch_end` produces the same F1/accuracy shape as before (generation path is unchanged).
- [ ] Repeat briefly for `variant_effect_coding` and `variant_effect_non_snv` dataset types.
